### PR TITLE
Save console history between launches

### DIFF
--- a/objects/oDebugConsole/CleanUp_0.gml
+++ b/objects/oDebugConsole/CleanUp_0.gml
@@ -1,0 +1,1 @@
+save_history();

--- a/objects/oDebugConsole/Create_0.gml
+++ b/objects/oDebugConsole/Create_0.gml
@@ -89,5 +89,39 @@ commands =
 	
 	"perf" : function(_args) {
 		show_debug_overlay(	! is_debug_overlay_open())
+	},
+	
+	"bb" : function(_args) { array_insert(oBossControlQuest.bosses_array, 0, _args[0]); oBossControlQuest.timer = 0; },
+}
+
+
+
+// Load history
+
+filename = "console_history"; // Filename to save history to
+key_name = "history"; // The key in saved ds map where history is stored
+
+history_size_limit = 100; // max number of entries in history
+
+if (file_exists(filename))
+{
+	var _saved_history = ds_map_secure_load(filename);
+	if (_saved_history != -1)
+	{
+		cmd_history = ds_map_find_value(_saved_history, key_name);
 	}
 }
+
+
+
+// Save history
+save_history = function()
+{
+	var _ds_map_for_saving = ds_map_create();
+	
+	ds_map_add_list(_ds_map_for_saving, key_name, cmd_history);
+	ds_map_secure_save(_ds_map_for_saving, filename);
+	
+	ds_map_destroy(_ds_map_for_saving);
+}
+

--- a/objects/oDebugConsole/Step_0.gml
+++ b/objects/oDebugConsole/Step_0.gml
@@ -6,6 +6,7 @@ if keyboard_check_pressed(192) || keyboard_check_pressed(vk_alt) || (enabled && 
 	{
 		instance_deactivate_all(true);
 		instance_activate_object(oDrawer);
+		cmd_offset = -1;
 	}
 	else
 	{
@@ -19,32 +20,6 @@ if keyboard_check_pressed(192) || keyboard_check_pressed(vk_alt) || (enabled && 
 				array_copy(_args, 0, _cmd, 1, array_length(_cmd) - 1)
 				
 				commands[$ _cmd[0]](_args);
-				
-				//switch (_cmd[0])
-				//{
-				//	case "hp":
-				//		oPlayer.hp = int64(_cmd[1]);
-				//		break;
-				//	case "ammo":
-				//		oPlayer.bullets = int64(_cmd[1]);
-				//		break;
-				//	case "gun":
-				//		oPlayer.gun.current_gun = int64(_cmd[1]);
-				//		break;
-				//	case "boss":
-				//		array_insert(oBossControl.tmp_bosses_array, 0, _cmd[1]);		
-				//		break;
-				//	case "bossbegin":
-				//		oBossControl.timer = 0;
-				//		break;
-				//	case "spawnitem":
-				//		with (Create(oCamera.right, oGenerator.ground[0] - 100, oItemDrop, 0))
-				//		{
-				//			depth -= 2;
-				//			image = int64(_cmd[1]);
-				//		}
-				//		break;
-				//}
 			}
 			ds_list_clear(cmd_queue);
 		}
@@ -84,24 +59,20 @@ if keyboard_check_pressed(vk_enter)
 		
 		var _parse = string_split(keyboard_string, " ");
 		
-		//switch _parse[0]
-		//{
-		//	default:
-		//		ds_list_add(history, "Unknown command.");
-		//	break;
-		//	case "gun":
-		//	case "boss":
-		//	case "bossbegin":
-		//	case "spawnitem":
-		//	case "hp":
-		//	case "ammo":
-		//		ds_list_add(cmd_queue, _parse);
-		//	break;
-
-				
-		//}
 		ds_list_insert(history, 0, keyboard_string);
-		ds_list_insert(cmd_history, 0, keyboard_string);
+		
+		// Do not copy the command if it repeats the previous one
+		var _cur_history_size = ds_list_size(cmd_history);
+		if (_cur_history_size == 0 || keyboard_string != ds_list_find_value(cmd_history, 0))
+		{
+			ds_list_insert(cmd_history, 0, keyboard_string);
+		}
+		
+		// Store only the first 100 entries
+		while (ds_list_size(cmd_history) > history_size_limit)
+		{
+			ds_list_delete(cmd_history, ds_list_size(cmd_history) - 1);
+		}
 
 		if struct_exists(commands, _parse[0])
 		{

--- a/objects/oDebugConsole/oDebugConsole.yy
+++ b/objects/oDebugConsole/oDebugConsole.yy
@@ -5,6 +5,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":75,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":12,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"oDebugConsole",


### PR DESCRIPTION
- Add "bb" command that combines "boss" and "bossbegin" commands;
- Implement console history saving to a file;
- Clean up redundant commented code.